### PR TITLE
Add multi-stage mode64 bootloader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,7 @@
 /target/
 /out/
 
+### Memory dumps
+*.mem
+
 # TODO: add ignores on the go

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+.PHONY: clean
+
+source := src\main
+target := target
+
+all: bootloader
+
+bootloader:
+	if not exist "${target}\\" mkdir "${target}\\"
+	nasm ${source}\boot\bootloader.asm -f bin -o ${target}\bootloader.bin
+
+clean:
+	rmdir "${target}\\" /S /Q

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -6,5 +6,5 @@ if (!(Test-Path -Path $target)) {
     [void](New-Item -Type Directory -Force -Path $target)
 }
 
-Write-Host "Compile boot0 (NASM)"
-& nasm $source\boot\boot0.asm -f bin -o $target\boot0.bin
+Write-Host "Compile bootloader (NASM)"
+& nasm $source\boot\bootloader.asm -f bin -o $target\bootloader.bin

--- a/build/run.ps1
+++ b/build/run.ps1
@@ -1,2 +1,2 @@
 Write-Host "Starting emulator (QEMU, x86_64, raw)"
-& qemu-system-x86_64 -drive format=raw,file=..\target\boot0.bin
+& qemu-system-x86_64 -drive format=raw,file=..\target\bootloader.bin

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,7 +1,9 @@
 # Development Environment
 ## Toolchain
 The following toolchain will be needed for the development.
-- NASM
-- QEMU (for now)
+- **NASM**: to compile Assembly
+- **Make**: to build
+- **QEMU**: to emulate
+- **Binary tool**: to view binaries and hex-dumps
 
-Put each tool's binary on the PATH to be able to call it in the terminal and build scripts.
+Put each tool's binary on the PATH to be able to call it in the terminal and build scripts. <br>

--- a/src/main/boot/boot0.asm
+++ b/src/main/boot/boot0.asm
@@ -4,7 +4,6 @@
 boot_start:
   jmp 0x0:.mode16_main      ; Reload CS to 0 to fix boot segment discrepancy
   .mode16_main:
-    sti ; TODO: test if qemu clears ints
     xor ax, ax              ; Set segment registers to 0
     mov ds, ax
     mov es, ax
@@ -50,10 +49,10 @@ mode16_read_disk:
     mov si, dap
     mov ah, 0x42
     int 0x13
-    jc .print_disk_result_code
+    jc .disk_error
     ret
 
-  .print_disk_result_code: ; See: https://www.ctyme.com/intr/rb-0606.htm#Table234
+  .disk_error:
     mov si, msg_disk_error
     call mode16_print
     jmp halt
@@ -93,7 +92,7 @@ disk db 0x80
 msg_disk_error dw 20
 db 'Boot 0: DISK ERROR', 13, 10
 
-msg_boot0_ok dw 11
+msg_boot0_ok dw 12
 db 'Boot 0: OK', 13, 10
 
 times 510 - ($ - $$) db 0   ; Pad to 510 bytes

--- a/src/main/boot/boot0.asm
+++ b/src/main/boot/boot0.asm
@@ -1,70 +1,103 @@
 [bits 16]                   ; Use 16-bit instruction set for real mode
 [org 0x7c00]                ; Set origin address to the boot sector address
 
-cli                         ; Disable interrupts
+boot_start:
+  jmp 0x0:.mode16_main      ; Reload CS to 0 to fix boot segment discrepancy
+  .mode16_main:
+    sti ; TODO: test if qemu clears ints
+    xor ax, ax              ; Set segment registers to 0
+    mov ds, ax
+    mov es, ax
+    mov fs, ax
+    mov gs, ax
+    mov ss, ax
+    mov sp, boot_start      ; Set down-growing stack pointer to the start of the bootloader
+    cld                     ; Clear direction flag
 
-xor ax, ax                  ; Set AX=0.
-mov ds, ax                  ; Set DS to 0 through AX for lgdt (DS can't be set directly)
+  .mode16_load_boot1:
+    mov [disk], dl                              ; Store disk number of bootable disk
+    mov ax, (boot1_start - boot0_start) / 512   ; Start sector
+    mov cx, (kernel_end - boot1_start) / 512    ; Number of sectors
+    mov bx, boot1_start                         ; Buffer offset
+    xor dx, dx                                  ; Buffer segment
+    call mode16_read_disk                       ; Read upper boot stages from disk
 
-lgdt [gdt_desc]             ; Load the GDT into linear address space
+    mov si, msg_boot0_ok
+    call mode16_print
 
-mov eax, cr0                ; Set CR0[0] to 1 to enable protected mode.
-or eax, 1                   ; This has to be done through a 32-bit general-register, as
-mov cr0, eax                ; the control register can't be set directly
+    ;;; jmp boot1_main
+    jmp halt
 
-jmp 0x8:mode32_start        ; Far jump to the code segment to the address of the mode32_start label
+mode16_read_disk:
+  .verify_sector_count:
+    cmp cx, 127
+    jbe .read_disk
+    pusha
+    mov cx, 127
+    call mode16_read_disk
+    popa
+    add eax, 127
+    add dx, 127 * 512 / 16
+    sub cx, 127
+    jmp .verify_sector_count
 
-[bits 32]                   ; Use 32-bit instruction set for protected mode
-mode32_start:
-  mov ax, 0x10              ; Save data segment identifier
-  mov ds, ax                ; Set the data segment register to the valid data segment
-  mov ss, ax                ; Set the stack segment register to the valid data segment
-  mov esp, 0x90000          ; Set the stack pointer to 0x90000 (in free memory space of the first MB)
+  .read_disk:
+    mov [dap.lowerLBA], ax
+    mov [dap.sectorCount], cx
+    mov [dap.bufferSegment], dx
+    mov [dap.bufferOffset], bx
+    mov dl, [disk]
+    mov si, dap
+    mov ah, 0x42
+    int 0x13
+    jc .print_disk_result_code
+    ret
 
-; Test: clear video memory
-clear_vmem:
-  mov eax, 0xb8000
-  mov cx, 1000
-clear_vmem_loop:
-  mov word [ds:eax], 0x0720
-  add eax, 2
-  loop clear_vmem_loop
+  .print_disk_result_code: ; See: https://www.ctyme.com/intr/rb-0606.htm#Table234
+    mov si, msg_disk_error
+    call mode16_print
+    jmp halt
 
-; Test: write to video memory
-print_p:
-  mov byte [ds:0xb8000], 'P'  ; ASCII for P
-  mov byte [ds:0xb8001], 0x2a ; Set color mode
+mode16_print:
+  push ax
+  push cx
+  push si
+  mov cx, word [si]
+  add si, 2
+  .string_loop:
+    lodsb
+    mov ah, 0eh
+    int 10h
+  loop .string_loop, cx
+  pop si
+  pop cx
+  pop ax
+  ret
 
-; hang around
-keep_alive:
-  jmp keep_alive
+halt:
+  hlt
+  jmp halt
 
-; Global Descriptor Table
-; See: https://github.com/sentiment-software/sen-os-project/wiki/Bootloader
-gdt:                        ; GDT - Start address
-gdt_null:                   ; GDT - Null segment
-  dd 0
-  dd 0
-gdt_code:                   ; GDT - Code segment
-  dw 0xffff
-  dw 0
-  db 0
-  db 10011010b
-  db 11001111b
-  db 0
-gdt_data:                   ; GDT- Data segment
-  dw 0xffff
-  dw 0
-  db 0
-  db 10010010b
-  db 11001111b
-  db 0
-gdt_end:                    ; GDT - End address
+; Disk Address Packet
+dap:
+  .packetSize:    db 0x10 ; size of packet = 16 bytes
+  .dapNull:       db 0    ; always 0
+  .sectorCount:   dw 0x7F ; number of sectors to load (max = 127 on some BIOS)
+  .bufferOffset:  dw 0x0  ; 16-bit offset of target buffer
+  .bufferSegment: dw 0x0  ; 16-bit segment of target buffer
+  .lowerLBA:      dd 0x0  ; lower 32 bits of 48-bit starting LBA
+  .higherLBA:     dd 0x0  ; upper 32 bits of 48-bit starting LBA
 
-; GDT meta-descriptor
-gdt_desc:
-  dw gdt_end - gdt - 1      ; Calculate length (compile time)
-  dd gdt                    ; Set GDT Address
+disk db 0x80
+
+msg_disk_result_chr1 dw 1
+msg_disk_result_chr2 dw 1
+
+msg_disk_error dw 20
+db 'Boot 0: DISK ERROR', 13, 10
+
+msg_boot0_ok dw 11
+db 'Boot 0: OK', 13, 10
 
 times 510 - ($ - $$) db 0   ; Pad to 510 bytes
 dw 0xaa55                   ; Boot signature at 511:512 bytes

--- a/src/main/boot/boot0.asm
+++ b/src/main/boot/boot0.asm
@@ -25,8 +25,8 @@ boot_start:
     mov si, msg_boot0_ok
     call mode16_print
 
-    ;;; jmp boot1_main
-    jmp halt
+    jmp boot1_main           ; Jump to boot1
+    jmp halt                 ; Safely halt in case we somehow return here from boot1
 
 mode16_read_disk:
   .verify_sector_count:
@@ -89,9 +89,6 @@ dap:
   .higherLBA:     dd 0x0  ; upper 32 bits of 48-bit starting LBA
 
 disk db 0x80
-
-msg_disk_result_chr1 dw 1
-msg_disk_result_chr2 dw 1
 
 msg_disk_error dw 20
 db 'Boot 0: DISK ERROR', 13, 10

--- a/src/main/boot/boot1.asm
+++ b/src/main/boot/boot1.asm
@@ -1,0 +1,2 @@
+msg_check_loaded dw 16
+db 'Boot 1: LOADED', 13, 10

--- a/src/main/boot/boot1.asm
+++ b/src/main/boot/boot1.asm
@@ -1,2 +1,260 @@
-msg_check_loaded dw 16
-db 'Boot 1: LOADED', 13, 10
+[bits 16]
+
+boot1_main:
+  mov si, msg_boot1_start
+  call mode16_print
+
+  call check_mode64_support
+  test eax, eax
+  jz .mode64_not_supported
+
+  mov si, msg_mode64_supported
+  call mode16_print
+
+  call mode16_enable_a20
+  jmp halt
+  ;call init_paging
+  ;call remap_pic
+  ;call init_mode64
+
+  .mode64_not_supported:
+    mov si, msg_mode64_unsupported
+    call mode16_print
+    jmp halt
+
+check_mode64_support:
+  mov eax, 0x80000000 ; Test if extended processor info in available.
+  cpuid
+  cmp eax, 0x80000001
+  jb .not_supported
+
+  mov eax, 0x80000001 ; After calling CPUID with EAX = 0x80000001,
+  cpuid               ; all AMD64 compliant processors have the longmode-capable-bit
+  test edx, (1 << 29) ; (bit 29) turned on in the EDX (extended feature flags).
+
+  jz .not_supported   ; If it's not set, there is no long mode.
+  ret
+
+ .not_supported:
+    xor eax, eax
+    ret
+
+; Enable the A20 line using BIOS, keyboard controller or IO92 port.
+mode16_enable_a20:
+  call mode16_check_a20
+  test ax,ax
+  jnz .return
+
+  mov si, msg_a20_enable_with_bios
+  call mode16_print
+  call mode16_enable_a20_bios
+  call mode16_check_a20
+  cmp ax, ax
+  jnz .return
+
+  mov si, msg_a20_enable_with_keyboard
+  call mode16_print
+  call mode16_enable_a20_keyboard
+  call mode16_check_a20
+  cmp ax, ax
+  jnz .return
+
+  mov si, msg_a20_enable_with_io92
+  call mode16_print
+  call mode16_enable_a20_io92
+  call mode16_check_a20
+  cmp ax, ax
+  jnz .return
+
+  jmp halt               ; We couldn't enable A20, halt the CPU
+
+  .return:
+    ret
+
+; Checks whether A20 line is enabled.
+; Sets AX=0 if A20 is disabled, AX<>0 if it is enabled.
+mode16_check_a20:
+  pushf
+  push ds
+  push es
+  push di
+  push si
+  cli                         ; Disable interrupts
+
+  xor ax, ax                  ; ax = 0
+  mov es, ax                  ; es = 0
+  not ax                      ; ax = 0xFFFF
+  mov ds, ax                  ; ds = 0xFFFF
+  mov di, 0x0500              ; 0x0500 and 0x0510 are guaranteed to be free
+  mov si, 0x0510
+
+  mov dl, byte [es:di]        ; Save original values on these addresses
+  push dx
+  mov dl, byte [ds:si]
+  push dx
+
+  mov byte [es:di], 0x00      ; [es:di] is 0x0000:0x0500
+  mov byte [ds:si], 0xFF      ; [ds:si] is 0xFFFF:0x0510
+  cmp byte [es:di], 0xFF      ; If the A20 line is disabled, [es:di] will contain 0xFF
+  je .a20_disabled            ; A20 disabled
+  jmp .a20_enabled            ; A20 enabled
+  .a20_enabled:
+    mov si, msg_a20_enabled
+    call mode16_print
+    mov ax, 1
+    jmp .restore_values
+  .a20_disabled:
+    mov si, msg_a20_disabled
+    call mode16_print
+    mov ax, 0
+    jmp .restore_values
+  .restore_values:
+    pop dx
+    mov byte [ds:si], dl
+    pop dx
+    mov byte [es:di], dl
+    pop si
+    pop di
+    pop es
+    pop ds
+    popf
+    sti
+    ret
+
+; Enables A20 line using BIOS interrupt.
+; Set AX=0 on failure, AX<>0 on success.
+mode16_enable_a20_bios:
+  mov ax,2403h          ; Query A20 gate Support (later PS/2s systems)
+  int 15h
+  jb .failure           ; INT 15h is not supported
+  cmp ah, 0
+  jnz .failure          ; INT 15h is not supported
+  mov ax, 2402h         ; Get A20 gate Status
+  int 15h
+  jb .failure           ; Couldn't get status
+  cmp ah, 0
+  jnz .failure          ; Couldn't get status
+  cmp al, 1
+  jz .success           ; A20 is already activated
+  mov ax, 2401h         ; Enable A20 gate
+  int 15h
+  jb .failure           ; Couldn't enable the A20 gate
+  cmp ah, 0
+  jnz .failure          ; Couldn't enable the A20 gate
+ .success:
+    mov ax, 1
+    ret
+ .failure:
+    mov ax, 0
+    ret
+
+; Enables A20 line using the keyboard controller
+mode16_enable_a20_keyboard:
+  cli                    ; Disable interrupts
+  call a20wait
+  mov al, 0xad           ; Disable keyboard.
+  out 0x64, al
+  call a20wait
+  mov al, 0xd0           ; Read from input.
+  out 0x64, al
+  call a20wait2
+  in al,0x60
+  push eax
+  call a20wait
+  mov al, 0xd1           ; Write to output.
+  out 0x64, al
+  call a20wait
+  pop eax
+  or al, 2
+  out 0x60, al
+  call a20wait
+  mov al, 0xae           ; Enable keyboard.
+  out 0x64, al
+  call a20wait
+  sti                    ; Enables interrupts.
+  ret
+
+a20wait:
+  in      al, 0x64
+  test    al, 2
+  jnz     a20wait
+  ret
+
+a20wait2: ; TODO: check if needed
+  in      al, 0x64
+  test    al, 1
+  jz      a20wait2
+  ret
+
+; Enables A20 line using port 92
+mode16_enable_a20_io92:
+  in al, 0x92  ; Read from port 0x92
+  test al, 2   ; Check if bit al[1] is set.
+  jnz .return  ; If bit al[1] is already set, return.
+  or al, 2     ; Set al[1].
+  and al, 0xFE ; Make sure bit 0 is 0 (it causes a fast reset).
+  out 0x92, al ; Write to port 0x92
+ .return:
+   ret
+
+; Global Descriptor Table
+; Read/Write, Non-Conforming, Expand-Down
+gdt:
+gdt_null:
+  dq 0x0000000000000000  ; Null segment
+gdt_code:
+  dw 0xffff              ; Limit bits 0-15 (ignored in mode 64)
+  dw 0x0000              ; Base bits 0-15 (ignored in mode 64)
+  db 0x00                ; Base bits 16-23 (ignored in mode 64)
+  db 10011010b           ; Access byte
+  db 10100000b           ; Flags and limit bits 16-19
+  db 0x00                ; Base bits 24-31 (ignored in mode 64)
+gdt_data:
+  dw 0xffff              ; Limit bits 0-15 (in expand-down mode, limit is the lower bound)
+  dw 0x0000              ; Base bits 0-15
+  db 0x00                ; Base bits 16-23
+  db 10010010b           ; Access byte
+  db 11000000b           ; Flags and limit bits 16-19
+  db 0x00                ; Base bits 24-31
+gdt_end:
+
+gdt_desc:
+  dw gdt_end - gdt - 1
+  dd gdt
+
+; Messages
+msg_boot1_start dw 15
+db 'Boot 1: START', 13, 10
+msg_mode64_supported dw 26
+db 'Boot 1: MODE64 SUPPORTED', 13, 10
+msg_mode64_unsupported dw 28
+db 'Boot 1: MODE64 UNSUPPORTED', 13, 10
+msg_a20_enabled dw 21
+db 'Boot 1: A20 ENABLED', 13, 10
+msg_a20_disabled dw 22
+db 'Boot 1: A20 DISABLED', 13, 10
+msg_a20_enable_with_bios dw 30
+db 'Boot 1: A20 ENABLE WITH BIOS', 13, 10
+msg_a20_enable_with_keyboard dw 45
+db 'Boot 1: A20 ENABLE WITH KEYBOARD CONTROLLER', 13, 10
+msg_a20_enable_with_io92 dw 30
+db 'Boot 1: A20 ENABLE WITH IO92', 13, 10
+
+; Constants
+PIC1_COMMAND    equ 0x20 ; Command port of 1st PIC
+PIC1_DATA       equ 0x21 ; Data port of 1st PIC
+PIC2_COMMAND    equ 0xA0 ; Command port of 2nd PIC
+PIC2_DATA       equ 0xA1 ; Data port of 2nd PIC
+PIC_EOI         equ 0x20 ; EOI (End of interrupt) command (= 0x20)
+
+ICW1_ICW4       equ 0x01 ; Initialization Command Word 4 is needed
+ICW1_SINGLE     equ 0x02 ; Single mode (0: Cascade mode)
+ICW1_INTERVAL4  equ 0x04 ; Call address interval 4 (0: 8)
+ICW1_LEVEL      equ 0x08 ; Level triggered mode (0: Edge mode)
+ICW1_INIT       equ 0x10 ; Initialization - required!
+
+ICW4_8086       equ 0x01 ; 8086/88 mode (0: MCS-80/85 mode)
+ICW4_AUTO_EOI   equ 0x02 ; Auto End Of Interrupt (0: Normal EOI)
+ICW4_BUF_SLAVE  equ 0x08 ; Buffered mode/slave
+ICW4_BUF_MASTER equ 0x0C ; Buffered mode/master
+ICW4_SFNM       equ 0x10 ; Special Fully Nested Mode

--- a/src/main/boot/bootloader.asm
+++ b/src/main/boot/bootloader.asm
@@ -1,0 +1,14 @@
+boot0_start:
+  times 90 db 0
+  %include "src\main\boot\boot0.asm"
+boot0_end:
+
+boot1_start:
+  %include "src\main\boot\boot1.asm"
+  align 512, db 0
+boot1_end:
+
+kernel_start:
+  %include "src\main\boot\kernel.asm"
+  align 512, db 0
+kernel_end:

--- a/src/main/boot/kernel.asm
+++ b/src/main/boot/kernel.asm
@@ -1,17 +1,15 @@
-[bits 64]                      ; Use 64 bit instruction set in long mode (I really wanted to write this for a while)
-
-%define DATA_SEG    0x0010
-%define VRAM       0xB8000
+[bits 64]                        ; Use 64 bit instruction set in long mode
+                                 ; I really wanted to write that for a while
 
 kernel_main:
-  mov ax, DATA_SEG              ; Set up segment registers
+  mov ax, 0x10                   ; Set up segment registers
   mov ds, ax
   mov es, ax
   mov fs, ax
   mov gs, ax
   mov ss, ax
 
-  mov edi, 0xb8000
+  mov edi, 0xb8000               ; Point to VRAM
 
   ; Test me!
   mov rax, 0x1F6C1F6C1F651F48
@@ -21,6 +19,6 @@ kernel_main:
   mov rax, 0x1F211F641F6C1F72
   mov [edi + 16], rax
 
-  .halt:
+  .halt_kernel:
     hlt
-    jmp .halt
+    jmp .halt_kernel

--- a/src/main/boot/kernel.asm
+++ b/src/main/boot/kernel.asm
@@ -1,2 +1,26 @@
-msg_check_loaded_k dw 16
-db 'Boot K: LOADED', 13, 10
+[bits 64]                      ; Use 64 bit instruction set in long mode (I really wanted to write this for a while)
+
+%define DATA_SEG    0x0010
+%define VRAM       0xB8000
+
+kernel_main:
+  mov ax, DATA_SEG              ; Set up segment registers
+  mov ds, ax
+  mov es, ax
+  mov fs, ax
+  mov gs, ax
+  mov ss, ax
+
+  mov edi, 0xb8000
+
+  ; Test me!
+  mov rax, 0x1F6C1F6C1F651F48
+  mov [edi], rax
+  mov rax, 0x1F6F1F571F201F6F
+  mov [edi + 8], rax
+  mov rax, 0x1F211F641F6C1F72
+  mov [edi + 16], rax
+
+  .halt:
+    hlt
+    jmp .halt

--- a/src/main/boot/kernel.asm
+++ b/src/main/boot/kernel.asm
@@ -9,16 +9,45 @@ kernel_main:
   mov gs, ax
   mov ss, ax
 
-  mov edi, 0xb8000               ; Point to VRAM
-
-  ; Test me!
-  mov rax, 0x1F6C1F6C1F651F48
-  mov [edi], rax
-  mov rax, 0x1F6F1F571F201F6F
-  mov [edi + 8], rax
-  mov rax, 0x1F211F641F6C1F72
-  mov [edi + 16], rax
+  call clear_screen
+  call print_welcome_message
 
   .halt_kernel:
     hlt
     jmp .halt_kernel
+
+clear_screen:
+  push rax
+  push cx
+  mov edi, 0xb8000             ; Set VRAM address
+  mov rax, 0x0020002000200020  ; Set to black spaces
+  mov cx, 100                  ; Init counter
+  .clear_loop:
+    mov [edi], rax
+    add edi, 8
+    dec cx
+    jnz .clear_loop
+  pop cx
+  pop rax
+  ret
+
+print_welcome_message:
+    mov edi, 0xb8000               ; Point to VRAM
+    ; Test me!
+    mov rax, 0x1f631f6c1f651f57
+    mov [edi], rax
+    mov rax, 0x1f201f651f6d1f6f
+    mov [edi + 8], rax
+    mov rax, 0x1f6d1f201f6f1f74
+    mov [edi + 16], rax
+    mov rax, 0x1f2d1f661f201f79
+    mov [edi + 24], rax
+    mov rax, 0x1f6e1f691f6b1f63
+    mov [edi + 32], rax
+    mov rax, 0x1f651f6b1f201f67
+    mov [edi + 40], rax
+    mov rax, 0x1f6c1f651f6e1f72
+    mov [edi + 48], rax
+    mov rax, 0x1F001F001F001f21
+    mov [edi + 56], rax
+    ret

--- a/src/main/boot/kernel.asm
+++ b/src/main/boot/kernel.asm
@@ -1,0 +1,2 @@
+msg_check_loaded_k dw 16
+db 'Boot K: LOADED', 13, 10


### PR DESCRIPTION
Added:
boot0: loads boot1 and kernel main from disk
boot1:
  - check mode64 support
  - enables a20 line
  - inits page tables
  - remaps PIC
  - inits mode64 (enable PAE and PM bits)
kernel:
  - setup segments, clear screen and print a delightful welcome message